### PR TITLE
Fix bug in predeploy script; requirements.txt not needed for DashR apps

### DIFF
--- a/predeploy.py
+++ b/predeploy.py
@@ -5,15 +5,12 @@ import subprocess
 from apps_directory_mapping import APPNAME_TO_DIRECTORY
 
 
-files = ["requirements.txt", "Procfile"]
-rfiles = ["Aptfile", "init.R"]
+pyfiles = ["requirements.txt", "Procfile"]
+rfiles = ["Aptfile", "init.R", "Procfile"]
 
 app_name = os.environ["DASH_APP_NAME"]
 
 app_path = os.path.join("apps", APPNAME_TO_DIRECTORY.get(app_name, app_name))
-
-for f in files:
-    shutil.copyfile(os.path.join(app_path, f), f)
 
 if "DOKKU_SCALE" in os.listdir(app_path):
     shutil.copyfile(os.path.join(app_path, "DOKKU_SCALE"), "DOKKU_SCALE")
@@ -21,5 +18,8 @@ if "DOKKU_SCALE" in os.listdir(app_path):
 if "-" in app_name and app_name.split("-")[0] == "dashr":
     for rfile in rfiles:
         shutil.copyfile(os.path.join(app_path, rfile), rfile)
+else:
+    for f in pyfiles:
+        shutil.copyfile(os.path.join(app_path, f), f)
 
 subprocess.run("python -m pip install -r requirements.txt".split(" "))


### PR DESCRIPTION
This PR makes a minor change to the logic of `predeploy.py` such that the script does not attempt to copy a `requirements.txt` script if the app name begins with `dashr-`.