### PR TITLE
Add init.R to config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
                   cp ~/dash-sample-apps/apps/"$APP"/Aptfile ~/dash-sample-apps/
                   cp ~/dash-sample-apps/apps/"$APP"/Procfile ~/dash-sample-apps/
                   cp ~/dash-sample-apps/apps/"$APP"/.buildpacks ~/dash-sample-apps/
+                  cp ~/dash-sample-apps/apps/"$APP"/init.R ~/dash-sample-apps/
                   # app.json tries to call python predeploy, which is not needed for R apps:
                   rm ~/dash-sample-apps/app.json
                   git config --global user.email '<>' # Leave email blank


### PR DESCRIPTION
Ensure that `init.R` is copied for each app, rather than using a single package install script across the entire monorepo.