### PR TITLE
Added R notes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,40 @@ to your app branch.
 
 See [project boilerplate!](https://github.com/plotly/dash-sample-apps#project-boilerplate)
 
+### Notes on adding a new Dash for R app
+
+Contributing an app written with Dash for R is very similar to the steps outlined above. 
+
+1. Make the folder have the _exact same_ name as the Dash app name.
+
+2. Ensure that the file containing your app code is named `app.R`.
+
+3. The `Procfile` should contain `web: R -f /app/apps/"$DASH_APP_NAME"/app.R`.
+
+4. Routing and request pathname prefixes should be set. One approach might be to include
+
+```
+appName <- Sys.getenv("DASH_APP_NAME")
+pathPrefix <- sprintf("/%s/", appName)
+
+Sys.setenv(DASH_ROUTES_PATHNAME_PREFIX = pathPrefix,
+           DASH_REQUESTS_PATHNAME_PREFIX = pathPrefix)
+```
+
+at the head of your `app.R` file.
+
+5. `run_server()` should be provided the host and port information explicitly, e.g.
+
+``
+app$run_server(host = "0.0.0.0", port = Sys.getenv('PORT', 8050))
+``
+
+6. For convenience, it is probably easiest to set the working directory in `app.R` as well:
+
+``
+setwd(sprintf("/app/apps/%s", appName))
+``
+
 ### Making changes to an existing app
 
 Switch to the branch that has the same name as the DDS app (the "app

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Contributing an app written with Dash for R is very similar to the steps outline
 
 2. Ensure that the file containing your app code is named `app.R`.
 
-3. The `Procfile` should contain `web: R -f /app/apps/"$DASH_APP_NAME"/app.R`.
+3. The `Procfile` should contain 
+
+```
+web: R -f /app/apps/"$DASH_APP_NAME"/app.R`
+```
 
 4. Routing and request pathname prefixes should be set. One approach might be to include
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Contributing an app written with Dash for R is very similar to the steps outline
 3. The `Procfile` should contain 
 
 ```
-web: R -f /app/apps/"$DASH_APP_NAME"/app.R`
+web: R -f /app/apps/"$DASH_APP_NAME"/app.R
 ```
 
 4. Routing and request pathname prefixes should be set. One approach might be to include


### PR DESCRIPTION
The current `README.md` is missing a few details that we might wish to include for future Dash for R app deployments. I have proposed to add them in here.