### PR TITLE
add pre-commit config for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: https://github.com/python/black
+    rev: stable
+    hooks:
+    - id: black
+      args: [--check]
+      exclude: 'venv/'
+      language_version: python3.6

--- a/README.md
+++ b/README.md
@@ -197,3 +197,10 @@ PR has two checkers.
 1. make sure your code passed the black linter
 2. make sure your project is deployed on dns playground
 ```
+
+#### Setup pre-commit hook
+
+1. install pre-commit (https://pre-commit.com/)
+2. run `pre-commit install` to install the hooks in `.git/` folder
+
+- config is defined in .pre-commit-config.yaml


### PR DESCRIPTION
Every time you commit, it will run the black checker.

1. install pre-commit (https://pre-commit.com/)
2. run `pre-commit install` to install the hooks in `.git/` folder

![image](https://user-images.githubusercontent.com/15094206/59936846-fd3bdf80-941e-11e9-966c-50f47a4b5112.png)

@shammamah you think this will be useful? If not, we can close this PR 😄 