### PR TITLE
Remove daq tektronix folder

### DIFF
--- a/apps/dash-daq-tektronix350/.vscode/settings.json
+++ b/apps/dash-daq-tektronix350/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "venv\\Scripts\\python.exe"
-}

--- a/apps/dashr-molecule3d/app.R
+++ b/apps/dashr-molecule3d/app.R
@@ -739,6 +739,7 @@ app$callback(
       content_string <- unlist(strsplit(contents, ","))[2]
       decoded <- jsonlite::base64_dec(content_string)
       pdbData <- get_pdb(rawToChar(decoded))
+      browser()
     } else return('demostr and contents are none')
 
     atom_data <- pdbData$atom


### PR DESCRIPTION
Accidentally added a directory `dash-daq-tektronix350/.vscode` when merging previous app to master app. This PR is just removing that folder.