### PR TITLE
fix pathlib handling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,17 @@ Tips
 
 ```Python
 import pathlib
+import pandas as pd
 
-# get relative assets folder
-html.Img(src=app.get_asset_url('logo'))                   
+# get relative assets
+html.Img(src=app.get_asset_url('logo.png'))       # /assets/logo.png
 
-# get relative data folder
-DATA_PATH = pathlib.Path(__file__, "/data")      # /data
-with open(DATA_PATH.joinpath("data.csv")) as f:  # /data/data.csv
+# get relative data
+
+DATA_PATH = pathlib.Path(__file__).parent.joinpath("data")  # /data
+df = pd.read_csv(DATA_PATH.joinpath("sample-data.csv"))    # /data/sample-data.csv
+
+with open(DATA_PATH.joinpath("sample-data.csv")) as f:  # /data/sample-data.csv
     some_string = f.read()
 ```
 


### PR DESCRIPTION
This PR aims to fix handling relative path in README.md.

```
DATA_PATH = pathlib.Path(__file__, "/data")
```  
will result in `/data` at app.py level, this cannot be recognized as correct path.  
parent folder should be defined as 
```
DATA_PATH = pathlib.Path(__file__).parent
```

