### PR TITLE
Dash oil and gas app fix

### DIFF
--- a/apps/dash-oil-and-gas/app.py
+++ b/apps/dash-oil-and-gas/app.py
@@ -162,6 +162,7 @@ app.layout = html.Div(
                             id="lock_selector",
                             options=[{"label": "Lock camera", "value": "locked"}],
                             className="dcc_control",
+                            value=[],
                         ),
                         html.P("Filter by well type:", className="control_label"),
                         dcc.RadioItems(
@@ -260,6 +261,8 @@ app.layout = html.Div(
 
 # Helper functions
 def human_format(num):
+    if num == 0:
+        return "0"
 
     magnitude = int(math.log(num, 1000))
     mantissa = str(int(num / (1000 ** magnitude)))
@@ -450,14 +453,16 @@ def make_main_figure(
         )
         traces.append(trace)
 
-    if main_graph_layout is not None and "locked" in selector:
 
-        lon = float(main_graph_layout["mapbox"]["center"]["lon"])
-        lat = float(main_graph_layout["mapbox"]["center"]["lat"])
-        zoom = float(main_graph_layout["mapbox"]["zoom"])
-        layout["mapbox"]["center"]["lon"] = lon
-        layout["mapbox"]["center"]["lat"] = lat
-        layout["mapbox"]["zoom"] = zoom
+    if main_graph_layout is not None and selector is not None and "locked" in selector:
+        if "mapbox.center" in main_graph_layout.keys(): #relayoutData is None by default, and {'autosize': True} without relayout action
+
+            lon = float(main_graph_layout["mapbox.center"]["lon"])
+            lat = float(main_graph_layout["mapbox.center"]["lat"])
+            zoom = float(main_graph_layout["mapbox.zoom"])
+            layout["mapbox"]["center"]["lon"] = lon
+            layout["mapbox"]["center"]["lat"] = lat
+            layout["mapbox"]["zoom"] = zoom
 
     figure = dict(data=traces, layout=layout)
     return figure

--- a/apps/dash-oil-and-gas/app.py
+++ b/apps/dash-oil-and-gas/app.py
@@ -453,11 +453,9 @@ def make_main_figure(
         )
         traces.append(trace)
 
+    # relayoutData is None by default, and {'autosize': True} without relayout action
     if main_graph_layout is not None and selector is not None and "locked" in selector:
-        if (
-            "mapbox.center" in main_graph_layout.keys()
-        ):  # relayoutData is None by default, and {'autosize': True} without relayout action
-
+        if "mapbox.center" in main_graph_layout.keys():
             lon = float(main_graph_layout["mapbox.center"]["lon"])
             lat = float(main_graph_layout["mapbox.center"]["lat"])
             zoom = float(main_graph_layout["mapbox.zoom"])

--- a/apps/dash-oil-and-gas/app.py
+++ b/apps/dash-oil-and-gas/app.py
@@ -453,9 +453,10 @@ def make_main_figure(
         )
         traces.append(trace)
 
-
     if main_graph_layout is not None and selector is not None and "locked" in selector:
-        if "mapbox.center" in main_graph_layout.keys(): #relayoutData is None by default, and {'autosize': True} without relayout action
+        if (
+            "mapbox.center" in main_graph_layout.keys()
+        ):  # relayoutData is None by default, and {'autosize': True} without relayout action
 
             lon = float(main_graph_layout["mapbox.center"]["lon"])
             lat = float(main_graph_layout["mapbox.center"]["lat"])


### PR DESCRIPTION
fixes https://github.com/plotly/dash-sample-apps/issues/337

Updated deployment on playground **https://dash-playground.plotly.host/dash-oil-and-gas/**

###### Problem:
1. map doesn't load because of mishandling of `relayoutData` inside callback - {'autosize': True} is not considered and key is not correct.

<img width="1263" alt="Screen Shot 2019-10-17 at 11 04 32 AM" src="https://user-images.githubusercontent.com/35306149/67028571-8ddab180-f0d9-11e9-95fa-c4397207145f.png">

After fix mapbox should be loading upon app loading,  and when controls in control panel is updated.

2. Fix a math error raised when `Customized` is set in well-status and no item/category in dropdown.

