### PR TITLE
#351 follow up

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
                   echo "Deploy failed because there is no assets/ folder. Exiting..."
                   exit 1
                 fi
-                git add ~/dash-sample-apps/apps/"$APP"/assets/plotly_ga.js && git commit -m "Deployed commit: $CIRCLE_SHA1"
+                git commit -m "Deployed commit: $CIRCLE_SHA1"
                 git push playground $CIRCLE_BRANCH:master --force
                 exit 0
               else
@@ -100,7 +100,7 @@ jobs:
               git config --global user.name "Circle MonoRepo Automatic Deployer"
               if [ -d ~/dash-sample-apps/apps/"$APP"/ ]
               then
-                git add ~/dash-sample-apps/apps/"$APP"/assets/plotly_ga.js && git commit -m "Deployed commit: $CIRCLE_SHA1"
+                git commit -m "Deployed commit: $CIRCLE_SHA1"
                 git remote add $APP https://dash-playground.plotly.host/GIT/$APP
                 git push $APP master --force || echo "Deploy failed because there is no such app on Dash Gallery: $APP. Please use the web interface to create an app with this name. Continuing deployments..."
               fi

--- a/predeploy.py
+++ b/predeploy.py
@@ -44,8 +44,10 @@ app_file_name = ""
 with open(os.path.join(app_path, "Procfile"), "r") as f:
     contents = f.read().split(" ")
     for item in contents:
-        if "server" in item:
+        if "server" or "SERVER" in item:
             app_file_name = item.split(":")[0]
+        else:
+            print("'server' or 'SERVER' not found in Procfile")
 
 full_app_path = os.path.join(app_path, app_file_name + ".py")
 

--- a/predeploy.py
+++ b/predeploy.py
@@ -44,10 +44,8 @@ app_file_name = ""
 with open(os.path.join(app_path, "Procfile"), "r") as f:
     contents = f.read().split(" ")
     for item in contents:
-        if "server" or "SERVER" in item:
+        if "server" in item:
             app_file_name = item.split(":")[0]
-        else:
-            print("'server' or 'SERVER' not found in Procfile")
 
 full_app_path = os.path.join(app_path, app_file_name + ".py")
 


### PR DESCRIPTION
https://github.com/plotly/dash-sample-apps/pull/351 made a test deploy of adding new google tag upon playground deployment. 

I went through list in above deployment, and found out that I've missed initializing part of app list (my bad) on server panel.
<img width="668" alt="Screen Shot 2019-11-12 at 5 02 28 PM" src="https://user-images.githubusercontent.com/35306149/68714639-3d3a6500-056e-11ea-9d98-380830a77630.png">

For apps that have been deployed successfully, only one app `dash-nlp` is encountering problem because it declared `SERVER` instead of `server` in Procfile so `predeploy` is unable to locate `app:SERVER`. Handled by https://github.com/plotly/dash-sample-apps/commit/17cd6c840c71178e95138d6fbf552cd50ce8eeb8

This PR does minor fix including:
- [x] Add missing python apps for a re-deploy validation
- [x] Remove unnecessary old js git add command
- [x] We missed a condition of apps carrying enviromnental variable as app settings.  `dash-salesforce-crm` and `dash-image-processing` are two examples I could think about, and I've added for both on test server app settings.

 @shammamah  Let me know whether we could get this merged before meeting with @VeraZab for a checkup.