### PR TITLE
css fix for calendar alignment issues

### DIFF
--- a/apps/dash-mapd-demo/assets/dash-mapd.css
+++ b/apps/dash-mapd-demo/assets/dash-mapd.css
@@ -117,3 +117,7 @@ body {
         width: 50%;
     }
 }
+
+.CalendarMonth_table td {
+  padding: unset;  
+}

--- a/apps/dash-uber-rides-demo/assets/style.css
+++ b/apps/dash-uber-rides-demo/assets/style.css
@@ -204,4 +204,6 @@ a {
   background: #d8d8d870 !important; 
 }
 
-
+.CalendarMonth_table td {
+  padding: unset;  
+}

--- a/apps/dashr-uber-rides/assets/style.css
+++ b/apps/dashr-uber-rides/assets/style.css
@@ -600,4 +600,6 @@ a {
   background: #d8d8d870 !important; 
 }
 
-
+.CalendarMonth_table td {
+  padding: unset;  
+}


### PR DESCRIPTION
Issue for apps: dash / dashr Uber apps, mapd-demo

# App pull request
- [ ] This is a new app
- [x] I am improving an existing app (redesigns/code "makeovers")

I noticed that all the apps that use `base.css` and the date picker components have an issue in that the calendars don't display the full week because of padding being added to `td` in `base.css`. So the header shows all 7 days of the week, but the dates for Saturdays are being pushed and aren't actually accessible to the user

![2020-01-21_13:48:08](https://user-images.githubusercontent.com/19624164/72833385-bcc26f80-3c54-11ea-8660-9714a4deebb2.png)

This is an issue in the uber apps, and in the mapd-demo app. I've unset the padding on `.CalendarMonth_table td` in each of their respective stylesheets, which fixes the issue without inadvertently messing up the style for other `td` elements:

![2020-01-21_13:52:45](https://user-images.githubusercontent.com/19624164/72833708-5f7aee00-3c55-11ea-90ed-9a662128a159.png)
