### PR TITLE
feat: add support for creating redis/postgres services if needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - run:
           name: Install dds-client
           command: |
-            curl -sSL -o dds-client.tgz https://github.com/plotly/dds-client/releases/download/v0.1.0/dds-client_0.1.0_linux_x86_64.tgz
+            curl -sSL -o dds-client.tgz https://github.com/plotly/dds-client/releases/download/v0.3.0/dds-client_0.3.0_linux_x86_64.tgz
             mkdir $HOME/bin
             tar xzf dds-client.tgz -C $HOME/bin
             chmod +x $HOME/bin/dds-client

--- a/deploy
+++ b/deploy
@@ -107,8 +107,23 @@ main() {
     [[ -n "$celery_version" ]] && log-info "celery python version: $(cat "$app_dir/requirements.txt" | grep -E "^celery=")"
     [[ -n "$redis_version" ]] && log-info "redis python version: $(cat "$app_dir/requirements.txt" | grep -E "^redis=")"
 
+    [[ -n "$sqlalchemy_version" ]] && log-info "sqlalchemy python version: $(cat "$app_dir/requirements.txt" | grep -E "^sqlalchemy=")"
+    [[ -n "$flask_sqlalchemy_version" ]] && log-info "flask-sqlalchemy python version: $(cat "$app_dir/requirements.txt" | grep -E "^flask-sqlalchemy=")"
+
+    if [[ -n "$sqlalchemy_version" ]] || [[ -n "$flask_sqlalchemy_version" ]]; then
+      if ! dds-client postgres:exists --name "$APP"; then
+        log-info "postgres not found, creating"
+        dds-client postgres:create --name "$APP"
+        dds-client postgres:link --name "$APP" --app "$APP"
+      fi
+    fi
+
     if [[ -n "$celery_version" ]] || [[ -n "$redis_version" ]]; then
-      log-exit "Skipping service that requires a redis instance"
+      if ! dds-client redis:exists --name "$APP"; then
+        log-info "redis not found, creating"
+        dds-client redis:create --name "$APP"
+        dds-client redis:link --name "$APP" --app "$APP"
+      fi
     fi
   fi
 


### PR DESCRIPTION
At the moment, apps that require either will fail to deploy.

Note that this may end up linking an app twice to a service, so we need to audit this roll-out to 'recreate' those apps.


## About

N/A

## Workflow

- [x] I have created a branch in the appropriate monorepo, and the
  elements necessary for successful deployment are in place.

## The pre-review review

I have addressed all of the following questions:

- [x] Does everything in my code serve some purpose? (I have removed
  any dead and/or irrelevant code.)
- [x] Does everything in my code have a clear purpose? (My code is
  readable and, where it isn't, it has been commented appropriately.)]
- [x] Am I reinventing the wheel? (I have used appropriate packages to
  lessen the volume of code that needs to be maintained.)
