### PR TITLE
[FIX] Dash-cytoscape-lda: Downgrade scikit-learn to 0.20.1

### DIFF
--- a/apps/dash-cytoscape-lda/requirements.txt
+++ b/apps/dash-cytoscape-lda/requirements.txt
@@ -65,7 +65,7 @@ requests==2.23.0
 retrying==1.3.3
 rsa==4.0
 s3transfer==0.3.3
-scikit-learn==0.23.0
+scikit-learn==0.20.1
 scipy==1.4.1
 six==1.14.0
 sklearn==0.0


### PR DESCRIPTION
🔥 🔥 🔥 