### PR TITLE
updating dash-uber-rides-demo to dash 1.12.0

### DIFF
--- a/apps/dash-uber-rides-demo/requirements.txt
+++ b/apps/dash-uber-rides-demo/requirements.txt
@@ -1,3 +1,3 @@
-dash==1.0.0
+dash==1.12.0
 pandas==0.24.1
 gunicorn==19.9.0


### PR DESCRIPTION
Upgrading this app to use dash==1.12.0 . The upgrade will allow for a domain restriction to be placed on the mapbox token for the gallery apps without encountering map rendering issues. See #426  for details

# App pull request
- [ ] This is a new app
- [x] I am improving an existing app (redesigns/code "makeovers")

## About

- Playground deployment URL (new version): https://dash-playground.plotly.host/dash-uber-rides-demo/
- Current gallery app URL: https://dash-gallery.plotly.host/dash-uber-rides-demo/

## Workflow

- [x] I have created a branch in the appropriate monorepo, and the
  elements necessary for successful deployment are in place.
- [x] If the app is a redesigned and/or restyled version of an
  existing gallery app, I've summarized the changes requested in the
  appropriate Streambed issue and confirm that they have been applied.
- [x] If the app is on the Dash Gallery portal, I have added a link to
  the GitHub repository for the source code in the portal description.
- [x] If the app is a reimplementation of a Python gallery app for the
  DashR gallery, the app in this PR mimics, as closely as possible,
  the style and functionality of the existing app.=
- [x] I have removed *all Google Analytics code* from the app's
  `assets/` folder.

## The pre-review review

I have addressed all of the following questions:

- [x] Does everything in my code serve some purpose? (I have removed
  any dead and/or irrelevant code.)
- [x] Does everything in my code have a clear purpose? (My code is
  readable and, where it isn't, it has been commented appropriately.)]
- [x] Am I reinventing the wheel? (I have used appropriate packages to
  lessen the volume of code that needs to be maintained.)
