### PR TITLE
Fix `app.run_server` in Dash Image Enhancing Notebook

### DIFF
--- a/apps/dash-image-enhancing/ColabDemo.ipynb
+++ b/apps/dash-image-enhancing/ColabDemo.ipynb
@@ -3,7 +3,7 @@
   "nbformat_minor": 0,
   "metadata": {
     "colab": {
-      "name": "JupyterDash TF2 Image Enhancer.ipynb",
+      "name": "Dash Image Enhancing with ESRGAN.ipynb",
       "provenance": [],
       "collapsed_sections": []
     },
@@ -34,7 +34,7 @@
       "source": [
         "!pip install dash-bootstrap-components jupyter-dash plotly -q"
       ],
-      "execution_count": 1,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -187,7 +187,7 @@
         "    fluid=True,\n",
         ")"
       ],
-      "execution_count": 21,
+      "execution_count": 5,
       "outputs": []
     },
     {
@@ -210,7 +210,7 @@
       "source": [
         "model = hub.load(\"https://tfhub.dev/captain-pool/esrgan-tf2/1\")"
       ],
-      "execution_count": 9,
+      "execution_count": 6,
       "outputs": []
     },
     {
@@ -250,7 +250,7 @@
         "\n",
         "    return lr, sr"
       ],
-      "execution_count": 22,
+      "execution_count": 7,
       "outputs": []
     },
     {
@@ -271,7 +271,7 @@
         "colab": {}
       },
       "source": [
-        "app.run_server(mode='internal')"
+        "app.run_server(mode='inline', height=700)"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Issue for app: #[issue number here]

# App pull request
- [ ] This is a new app
- [ ] I am improving an existing app (redesigns/code "makeovers")

## About

- Playground deployment URL (new version):
- Current gallery app URL: (delete this line if inapplicable)
- Python app repository link: (delete this line if you are working on a Python app)

## Workflow

- [ ] I have created a branch in the appropriate monorepo, and the
  elements necessary for successful deployment are in place.
- [ ] If the app is a redesigned and/or restyled version of an
  existing gallery app, I've summarized the changes requested in the
  appropriate Streambed issue and confirm that they have been applied.
- [ ] If the app is on the Dash Gallery portal, I have added a link to
  the GitHub repository for the source code in the portal description.
- [ ] If the app is a reimplementation of a Python gallery app for the
  DashR gallery, the app in this PR mimics, as closely as possible,
  the style and functionality of the existing app.=
- [ ] I have removed *all Google Analytics code* from the app's
  `assets/` folder.

## The pre-review review

I have addressed all of the following questions:

- [ ] Does everything in my code serve some purpose? (I have removed
  any dead and/or irrelevant code.)
- [ ] Does everything in my code have a clear purpose? (My code is
  readable and, where it isn't, it has been commented appropriately.)]
- [ ] Am I reinventing the wheel? (I have used appropriate packages to
  lessen the volume of code that needs to be maintained.)
