### PR TITLE
add dash-mapd-demo to .deployignore for cost savings

### DIFF
--- a/.deployignore
+++ b/.deployignore
@@ -5,3 +5,4 @@ dash-cuml-umap
 dash-chatbot
 dash-translate
 dash-image-enhancing
+dash-mapd-demo


### PR DESCRIPTION
For continual cost saving measures, we are removing this demo application as it costs ~$200/m and doesn't directly drive value. 
