### PR TITLE
Fix Deck Explorer Redirect

### DIFF
--- a/apps/dash-deck-explorer/app.py
+++ b/apps/dash-deck-explorer/app.py
@@ -103,7 +103,7 @@ def update_url(name):
     Input("url", "pathname"),
 )
 def update_demo(pathname):
-    if pathname in ["/dash-deck-explorer/", None, "/"]:
+    if pathname in ["/dash-deck-explorer/", "/dash-deck-explorer", None, "/"]:
         return dash.no_update
 
     name = pathname.split("/")[-1]


### PR DESCRIPTION
Seems like you can't directly access a demo using a URL, e.g. http://dash-gallery.plotly.host/dash-deck-explorer/hexagon-layer will not show the hexagon-layer