### PR TITLE
Add automation to automatically release zipped apps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+# https://github.com/actions/upload-release-asset/issues/28#issuecomment-617208601
+on:
+  push:
+    branches:
+      - master
+
+name: Release and upload apps
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump version and push tag
+        id: version_bump
+        uses: anothrNick/github-tag-action@1.34.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+      - name: Compress apps
+        run: |
+          cd ./apps;
+          for f in */; do
+            echo "Zipping ${f}...";
+            zip -qr "${f%/*}" "${f}"*;
+          done
+          cd -;
+      - name: Create release and upload zipped apps
+        run: |
+          cd ./apps;
+          set -x
+          assets=()
+          for asset in ./*.zip; do
+            assets+=("-a" "$asset")
+          done
+          hub release create "${assets[@]}" -m "Release ${RELEASE_TAG}" "${RELEASE_TAG}"
+          cd -;
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version_bump.outputs.new_tag }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a monorepo designed to host all of the apps that have been
 created for the Python Dash Gallery.
 
-## Running an example app
+## Running an example app after cloning the repo
 
 You will need to run applications, and specify filenames, from the
 root directory of the repository. e.g., if the name of the app you
@@ -13,6 +13,20 @@ of the repository.
 
 Each app has a requirements.txt, install the dependecies in a virtual
 environment.
+
+## Downloading and running a single app
+
+If you don't want to clone the entire repo, you can also download an individual app as a zip file (see the [releases](https://github.com/plotly/dash-sample-apps/releases)), decompress and run them. In the example below, replace `<name>` by the name of the app:
+
+```bash
+wget https://github.com/plotly/dash-sample-apps/releases/latest/download/<name>.zip
+unzip <name>.zip
+cd <name>/
+python -m venv venv
+source venv/bin/activate  # Windows: \venv\scripts\activate
+pip install -r requirements.txt
+python app.py
+```
 
 ## Contributing to the sample apps repo
 

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ environment.
 
 ## Downloading and running a single app
 
-If you don't want to clone the entire repo, you can also download an individual app as a zip file (see the [releases](https://github.com/plotly/dash-sample-apps/releases)), decompress and run them. In the example below, replace `<name>` by the name of the app:
+Visit the [releases page](https://github.com/plotly/dash-sample-apps/releases) and download and `unzip` the app you want. Then `cd` into the app directory and install its dependencies in a virtual environment in the following way:
 
 ```bash
-wget https://github.com/plotly/dash-sample-apps/releases/latest/download/<name>.zip
-unzip <name>.zip
-cd <name>/
 python -m venv venv
 source venv/bin/activate  # Windows: \venv\scripts\activate
 pip install -r requirements.txt
+```
+
+then run the app:
+```bash
 python app.py
 ```
 


### PR DESCRIPTION
Closes #559

Whenever a commit is pushed to master:
- Automatically bump version
- Compress each app directory into a zip file
- Create a release and upload all the zipped apps



Issue for app: #[issue number here]

# App pull request
- [ ] This is a new app
- [ ] I am improving an existing app (redesigns/code "makeovers")

## About

- Playground deployment URL (new version):
- Current gallery app URL: (delete this line if inapplicable)
- Python app repository link: (delete this line if you are working on a Python app)

## Workflow

- [ ] I have created a branch in the appropriate monorepo, and the
  elements necessary for successful deployment are in place.
- [ ] If the app is a redesigned and/or restyled version of an
  existing gallery app, I've summarized the changes requested in the
  appropriate Streambed issue and confirm that they have been applied.
- [ ] If the app is on the Dash Gallery portal, I have added a link to
  the GitHub repository for the source code in the portal description.
- [ ] If the app is a reimplementation of a Python gallery app for the
  DashR gallery, the app in this PR mimics, as closely as possible,
  the style and functionality of the existing app.=
- [ ] I have removed *all Google Analytics code* from the app's
  `assets/` folder.

## The pre-review review

I have addressed all of the following questions:

- [ ] Does everything in my code serve some purpose? (I have removed
  any dead and/or irrelevant code.)
- [ ] Does everything in my code have a clear purpose? (My code is
  readable and, where it isn't, it has been commented appropriately.)]
- [ ] Am I reinventing the wheel? (I have used appropriate packages to
  lessen the volume of code that needs to be maintained.)
