### PR TITLE
Add external database fallback

### DIFF
--- a/apps/dash-image-processing/app.py
+++ b/apps/dash-image-processing/app.py
@@ -18,6 +18,9 @@ from flask_caching import Cache
 import dash_reusable_components as drc
 import utils
 
+os.environ['REDIS_URL'] = os.getenv('REDIS_URL', os.getenv('EXTERNAL_REDIS_URL'))
+# os.environ['DATABASE_URL'] = os.getenv('DATABASE_URL', os.getenv('EXTERNAL_DATABASE_URL'))
+
 DEBUG = True
 LOCAL = False
 APP_PATH = str(pathlib.Path(__file__).parent.resolve())

--- a/apps/dash-image-processing/app.py
+++ b/apps/dash-image-processing/app.py
@@ -18,7 +18,7 @@ from flask_caching import Cache
 import dash_reusable_components as drc
 import utils
 
-os.environ['REDIS_URL'] = os.getenv('REDIS_URL', os.getenv('EXTERNAL_REDIS_URL'))
+os.environ["REDIS_URL"] = os.getenv("REDIS_URL", os.getenv("EXTERNAL_REDIS_URL"))
 # os.environ['DATABASE_URL'] = os.getenv('DATABASE_URL', os.getenv('EXTERNAL_DATABASE_URL'))
 
 DEBUG = True

--- a/apps/dash-interest-rate/app.py
+++ b/apps/dash-interest-rate/app.py
@@ -18,7 +18,7 @@ from sklearn import metrics
 
 from utils import *
 
-os.environ['REDIS_URL'] = os.getenv('REDIS_URL', os.getenv('EXTERNAL_REDIS_URL'))
+os.environ["REDIS_URL"] = os.getenv("REDIS_URL", os.getenv("EXTERNAL_REDIS_URL"))
 # os.environ['DATABASE_URL'] = os.getenv('DATABASE_URL', os.getenv('EXTERNAL_DATABASE_URL'))
 
 # Snowflake vars

--- a/apps/dash-interest-rate/app.py
+++ b/apps/dash-interest-rate/app.py
@@ -18,6 +18,8 @@ from sklearn import metrics
 
 from utils import *
 
+os.environ['REDIS_URL'] = os.getenv('REDIS_URL', os.getenv('EXTERNAL_REDIS_URL'))
+# os.environ['DATABASE_URL'] = os.getenv('DATABASE_URL', os.getenv('EXTERNAL_DATABASE_URL'))
 
 # Snowflake vars
 FLAKE_ACCOUNT = os.getenv("FLAKE_ACCOUNT")

--- a/apps/dash-loan-grade/app.py
+++ b/apps/dash-loan-grade/app.py
@@ -23,6 +23,8 @@ from sklearn.model_selection import train_test_split
 from sklearn.tree import DecisionTreeClassifier, plot_tree, export_graphviz
 from sklearn import metrics
 
+os.environ['REDIS_URL'] = os.getenv('REDIS_URL', os.getenv('EXTERNAL_REDIS_URL'))
+# os.environ['DATABASE_URL'] = os.getenv('DATABASE_URL', os.getenv('EXTERNAL_DATABASE_URL'))
 
 def connect_read_sql(query, engine):
     connection = engine.connect()

--- a/apps/dash-loan-grade/app.py
+++ b/apps/dash-loan-grade/app.py
@@ -23,8 +23,9 @@ from sklearn.model_selection import train_test_split
 from sklearn.tree import DecisionTreeClassifier, plot_tree, export_graphviz
 from sklearn import metrics
 
-os.environ['REDIS_URL'] = os.getenv('REDIS_URL', os.getenv('EXTERNAL_REDIS_URL'))
+os.environ["REDIS_URL"] = os.getenv("REDIS_URL", os.getenv("EXTERNAL_REDIS_URL"))
 # os.environ['DATABASE_URL'] = os.getenv('DATABASE_URL', os.getenv('EXTERNAL_DATABASE_URL'))
+
 
 def connect_read_sql(query, engine):
     connection = engine.connect()


### PR DESCRIPTION
For a few apps here, we want to add a fallback to an external database environment variable if the internal database doesn't work. This ensures compatibility with both Single server and DEK 4.x